### PR TITLE
Changed where condition of createbasequery and extended timeout of re…

### DIFF
--- a/arcgiscon_model.py
+++ b/arcgiscon_model.py
@@ -61,7 +61,7 @@ class EsriVectorQueryFactoy:
         
     @staticmethod    
     def createBaseQuery(extent=None, customFilter=None):        
-        allObjects = {"where":"objectid=objectid"}
+        allObjects = {"where":"1=1"}
         allFields = {"outfields":"*"}
         jsonFormat = {"f":"json"}                           
         query = {}            
@@ -221,7 +221,7 @@ class Connection:
                 auth = self.authMethod
                 if self.authMethod == ConnectionAuthType.NTLM:                    
                     auth = requests_ntlm.HttpNtlmAuth(self.username, self.password)              
-            request = requests.post(self.basicUrl + query.getUrlAddon(), params=query.getParams(), auth=auth, timeout=10)            
+            request = requests.post(self.basicUrl + query.getUrlAddon(), params=query.getParams(), auth=auth, timeout=60)            
         except requests.ConnectionError:
             raise
         except requests.HTTPError:


### PR DESCRIPTION
…quests

Changed 'where' condition from "where":"objectid=objectid" to "where":"1=1" in createBaseQuery method of EsriVectorQueryFactoy. There is a possiblity that table or feature layer's physical structure in the database does not have a field named literally 'objectid'. One example could be query layers published by AGS or external origin tables registered with geodatabase (there are cases, when the field will be named OBJECTID_1 or that some existing column name other than objectid will be used). I'm not sure what is the 'right' way to check the name of a field that has role of objectid but if someone needs to use objectid field name in query, there are several ways to check it . For example, fields that play a role of objectidfield have type set to 'esriFieldTypeOID'. Queries for 'returnIdsOnly' also return property: 'objectIdFieldName', so it could be obtained by querying with 'returnIdsOnly' and where='1=2'.

In createBaseQuery method case there's no need to look for objectid field name as 'objectid=objectid' is only an 'empty' condition. The condition "1=1"  is more general and should be equally suitable.

http://desktop.arcgis.com/en/arcmap/10.3/manage-data/using-sql-with-gdbs/object-id.htm

Timeout for queries also changed from 10 to 60 seconds.